### PR TITLE
feat: remove OwnerID, use ID from jwt token instead

### DIFF
--- a/controllers/board_controller.go
+++ b/controllers/board_controller.go
@@ -99,7 +99,9 @@ func (b *boardController) CreateBoard(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responseHelper.FailedResponse(fmt.Sprintf("Bad Request: %s", err.Error())))
 	}
 
-	if err := b.useCase.CreateBoard(&payload); err != nil {
+	userId := m.ExtractTokenUserId(c)
+
+	if err := b.useCase.CreateBoard(uint(userId), &payload); err != nil {
 		return c.JSON(http.StatusInternalServerError, responseHelper.FailedResponse(fmt.Sprintf("Error: %s", err.Error())))
 	}
 
@@ -117,7 +119,9 @@ func (b *boardController) UpdateBoard(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responseHelper.FailedResponse(fmt.Sprintf("Bad Request: %s", err.Error())))
 	}
 
-	if err := b.useCase.UpdateBoard(uint(id), &payload); err != nil {
+	userId := m.ExtractTokenUserId(c)
+
+	if err := b.useCase.UpdateBoard(uint(id), uint(userId), &payload); err != nil {
 		return c.JSON(http.StatusInternalServerError, responseHelper.FailedResponse(fmt.Sprintf("Error: %s", err.Error())))
 	}
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -56,8 +56,6 @@ func (u *userController) GetUser(c echo.Context) error {
 	}
 
 	var memberOf []*dto.BoardResponse
-
-	fmt.Print(user.MemberOf)
 	for _, board := range user.MemberOf {
 		memberOf = append(memberOf, &dto.BoardResponse{
 			ID:   board.ID,

--- a/dto/board_dto.go
+++ b/dto/board_dto.go
@@ -3,9 +3,8 @@ package dto
 import "time"
 
 type BoardRequest struct {
-	Name    string `json:"name,omitempty" validate:"required"`
-	Desc    string `json:"desc,omitempty" validate:"required"`
-	OwnerID uint   `json:"owner_id,omitempty" validate:"required"`
+	Name string `json:"name,omitempty" validate:"required"`
+	Desc string `json:"desc,omitempty" validate:"required"`
 }
 
 type BoardResponse struct {

--- a/repository/board/board_repository.go
+++ b/repository/board/board_repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"kanban-board/dto"
 	"kanban-board/model"
 
@@ -11,7 +12,7 @@ type BoardRepository interface {
 	Get() ([]model.Board, error)
 	GetById(id uint) (*model.Board, error)
 	Create(data *model.Board) error
-	Update(id uint, data *dto.BoardRequest) error
+	Update(id uint, issuerId uint, data *dto.BoardRequest) error
 	Delete(id uint) error
 }
 
@@ -69,7 +70,25 @@ func (b *boardRepository) Create(data *model.Board) error {
 	return nil
 }
 
-func (b *boardRepository) Update(id uint, data *dto.BoardRequest) error {
+func (b *boardRepository) Update(id uint, issuerId uint, data *dto.BoardRequest) error {
+	var board model.Board
+	// get board members
+	if err := b.db.Preload("Members").Where("id = ?", id).First(&board).Error; err != nil {
+		return err
+	}
+
+	var issuerIsMember bool
+	for _, member := range board.Members {
+		if member.ID == issuerId {
+			issuerIsMember = true
+			break
+		}
+	}
+
+	if !issuerIsMember {
+		return errors.New("Issuer is not member of this board!")
+	}
+
 	tx := b.db.Model(&model.Board{}).Where("id = ?", id).Updates(&data)
 	if tx.Error != nil {
 		return tx.Error

--- a/repository/board/mock_board_repository.go
+++ b/repository/board/mock_board_repository.go
@@ -29,8 +29,8 @@ func (m *mockBoardRepository) Create(data *model.Board) error {
 	return ret.Error(0)
 }
 
-func (m *mockBoardRepository) Update(id uint, data *dto.BoardRequest) error {
-	ret := m.Called(id, data)
+func (m *mockBoardRepository) Update(id uint, issuerId uint, data *dto.BoardRequest) error {
+	ret := m.Called(id, issuerId, data)
 	return ret.Error(0)
 }
 

--- a/repository/board_column/board_column_repository.go
+++ b/repository/board_column/board_column_repository.go
@@ -52,7 +52,6 @@ func (b *boardColumnRepository) Create(issuerId uint, data *model.BoardColumn) e
 	}
 
 	var issuerIsMember bool
-
 	for _, member := range board.Members {
 		if member.ID == issuerId {
 			issuerIsMember = true

--- a/usecase/board/board_usecase.go
+++ b/usecase/board/board_usecase.go
@@ -14,9 +14,9 @@ var validate = validator.New(validator.WithRequiredStructEnabled())
 type BoardUseCase interface {
 	GetBoards() ([]model.Board, error)
 	GetBoardById(id uint) (*model.Board, error)
-	CreateBoard(data *dto.BoardRequest) error
-	UpdateBoard(id uint, data *dto.BoardRequest) error
-	DeleteBoard(id uint, issuerUserId uint) error
+	CreateBoard(issuerId uint, data *dto.BoardRequest) error
+	UpdateBoard(id uint, issuerId uint, data *dto.BoardRequest) error
+	DeleteBoard(id uint, issuerId uint) error
 }
 
 type boardUseCase struct {
@@ -45,7 +45,7 @@ func (b *boardUseCase) GetBoardById(id uint) (*model.Board, error) {
 	return board, nil
 }
 
-func (b *boardUseCase) CreateBoard(data *dto.BoardRequest) error {
+func (b *boardUseCase) CreateBoard(issuerId uint, data *dto.BoardRequest) error {
 	err := validate.Struct(*data)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (b *boardUseCase) CreateBoard(data *dto.BoardRequest) error {
 	boardModel := &model.Board{
 		Name:    data.Name,
 		Desc:    data.Desc,
-		OwnerID: data.OwnerID,
+		OwnerID: issuerId,
 	}
 
 	if err := b.repo.Create(boardModel); err != nil {
@@ -64,27 +64,27 @@ func (b *boardUseCase) CreateBoard(data *dto.BoardRequest) error {
 	return nil
 }
 
-func (b *boardUseCase) UpdateBoard(id uint, data *dto.BoardRequest) error {
+func (b *boardUseCase) UpdateBoard(id uint, issuerId uint, data *dto.BoardRequest) error {
 	updatedData := &dto.BoardRequest{
 		Name: data.Name,
 		Desc: data.Desc,
 	}
 
-	if err := b.repo.Update(id, updatedData); err != nil {
+	if err := b.repo.Update(id, issuerId, updatedData); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (b *boardUseCase) DeleteBoard(id uint, issuerUserId uint) error {
+func (b *boardUseCase) DeleteBoard(id uint, issuerId uint) error {
 	// ensure user cannot delete other user's board
 	board, err := b.repo.GetById(id)
 	if err != nil {
 		return err
 	}
 
-	if board.OwnerID != issuerUserId {
+	if board.OwnerID != issuerId {
 		return errors.New("User only can delete board they owned!")
 	}
 

--- a/usecase/board/board_usecase_test.go
+++ b/usecase/board/board_usecase_test.go
@@ -97,22 +97,21 @@ func TestGetBoardById(t *testing.T) {
 func TestCreateBoard(t *testing.T) {
 	t.Run("Success Create Board", func(t *testing.T) {
 		data := &dto.BoardRequest{
-			Name:    "Board 1",
-			Desc:    "Board 1 Description",
-			OwnerID: 3,
+			Name: "Board 1",
+			Desc: "Board 1 Description",
 		}
-
+		issuerId := uint(3)
 		dataModel := &model.Board{
 			Name:    data.Name,
 			Desc:    data.Desc,
-			OwnerID: data.OwnerID,
+			OwnerID: issuerId,
 		}
 
 		mockRepo := boardRepo.NewMockBoardRepo()
 		mockRepo.On("Create", dataModel).Return(nil).Once()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.CreateBoard(data)
+		err := service.CreateBoard(issuerId, data)
 
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
@@ -120,59 +119,44 @@ func TestCreateBoard(t *testing.T) {
 
 	t.Run("Failed Create Board (Missing board name)", func(t *testing.T) {
 		data := &dto.BoardRequest{
-			Name:    "",
-			Desc:    "Board 1 Description",
-			OwnerID: 3,
+			Name: "",
+			Desc: "Board 1 Description",
 		}
+		issuerId := uint(3)
 
 		mockRepo := boardRepo.NewMockBoardRepo()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.CreateBoard(data)
+		err := service.CreateBoard(issuerId, data)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("Failed Create Board (Missing board desc)", func(t *testing.T) {
 		data := &dto.BoardRequest{
-			Name:    "Board 1",
-			Desc:    "",
-			OwnerID: 3,
-		}
-
-		mockRepo := boardRepo.NewMockBoardRepo()
-
-		service := NewBoardUseCase(mockRepo)
-		err := service.CreateBoard(data)
-
-		assert.Error(t, err)
-	})
-
-	t.Run("Failed Create Board (Missing OwnerId)", func(t *testing.T) {
-		data := &dto.BoardRequest{
 			Name: "Board 1",
-			Desc: "Board 1 Desc",
+			Desc: "",
 		}
+		issuerId := uint(3)
 
 		mockRepo := boardRepo.NewMockBoardRepo()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.CreateBoard(data)
+		err := service.CreateBoard(issuerId, data)
 
 		assert.Error(t, err)
 	})
 
 	t.Run("Failed Create Board (Internal Server Error)", func(t *testing.T) {
 		data := &dto.BoardRequest{
-			Name:    "Board 1",
-			Desc:    "Board 1 Description",
-			OwnerID: 3,
+			Name: "Board 1",
+			Desc: "Board 1 Description",
 		}
-
+		issuerId := uint(3)
 		dataModel := &model.Board{
 			Name:    data.Name,
 			Desc:    data.Desc,
-			OwnerID: data.OwnerID,
+			OwnerID: issuerId,
 		}
 
 		expectedErr := errors.New("Database Error")
@@ -180,7 +164,7 @@ func TestCreateBoard(t *testing.T) {
 		mockRepo.On("Create", dataModel).Return(expectedErr).Once()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.CreateBoard(data)
+		err := service.CreateBoard(issuerId, data)
 
 		assert.Error(t, err)
 		mockRepo.AssertExpectations(t)
@@ -199,12 +183,13 @@ func TestUpdateBoard(t *testing.T) {
 		boardRequest := &dto.BoardRequest{
 			Name: "Board 2",
 		}
+		issuerId := uint(3)
 
 		mockRepo := boardRepo.NewMockBoardRepo()
-		mockRepo.On("Update", boardToUpdate.ID, boardRequest).Return(nil).Once()
+		mockRepo.On("Update", boardToUpdate.ID, issuerId, boardRequest).Return(nil).Once()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.UpdateBoard(boardToUpdate.ID, boardRequest)
+		err := service.UpdateBoard(boardToUpdate.ID, issuerId, boardRequest)
 
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
@@ -214,12 +199,13 @@ func TestUpdateBoard(t *testing.T) {
 		boardRequest := &dto.BoardRequest{
 			Desc: "New Description",
 		}
+		issuerId := uint(3)
 
 		mockRepo := boardRepo.NewMockBoardRepo()
-		mockRepo.On("Update", boardToUpdate.ID, boardRequest).Return(nil).Once()
+		mockRepo.On("Update", boardToUpdate.ID, issuerId, boardRequest).Return(nil).Once()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.UpdateBoard(boardToUpdate.ID, boardRequest)
+		err := service.UpdateBoard(boardToUpdate.ID, issuerId, boardRequest)
 
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
@@ -229,13 +215,14 @@ func TestUpdateBoard(t *testing.T) {
 		boardRequest := &dto.BoardRequest{
 			Name: "Board 2",
 		}
+		issuerId := uint(3)
 
 		expectedErr := errors.New("Database Error")
 		mockRepo := boardRepo.NewMockBoardRepo()
-		mockRepo.On("Update", boardToUpdate.ID, boardRequest).Return(expectedErr).Once()
+		mockRepo.On("Update", boardToUpdate.ID, issuerId, boardRequest).Return(expectedErr).Once()
 
 		service := NewBoardUseCase(mockRepo)
-		err := service.UpdateBoard(boardToUpdate.ID, boardRequest)
+		err := service.UpdateBoard(boardToUpdate.ID, issuerId, boardRequest)
 
 		assert.Error(t, err)
 		mockRepo.AssertExpectations(t)

--- a/usecase/board_column/board_column_usecase.go
+++ b/usecase/board_column/board_column_usecase.go
@@ -65,7 +65,7 @@ func (b *boardColumnUseCase) CreateColumn(issuerId uint, data *dto.BoardColumnRe
 func (b *boardColumnUseCase) UpdateColumn(id uint, issuerId uint, data *dto.BoardColumnRequest) error {
 	updatedData := &dto.BoardColumnRequest{
 		Label: data.Label,
-		Desc: data.Desc,
+		Desc:  data.Desc,
 	}
 
 	if err := b.repo.Update(id, issuerId, updatedData); err != nil {


### PR DESCRIPTION
- Remove OwnerID and use ID from jwt token instead
- Add member check on board update endpoint